### PR TITLE
feat: Add support for multi-level nesting in bones layout

### DIFF
--- a/packages/npm/src/hooks/useGetBones.tsx
+++ b/packages/npm/src/hooks/useGetBones.tsx
@@ -23,40 +23,33 @@ interface UseGetBonesProps {
 export const useGetBones = (componentSize: IComponentSize) => {
   const renderBone = useRenderBone(componentSize);
 
+  const renderNestedBones = (bones: ICustomViewStyle[], prefix: string | number | undefined, generalStyles: IGeneralStyles) => {
+    return bones.map((bone, index) => {
+      const keyIndex = prefix ? `${prefix}_${index}` : index;
+
+      const { children: childBones, ...layoutStyle } = bone;
+
+      if (childBones?.length) {
+        return (
+            <View key={keyIndex} style={layoutStyle}>
+              {renderNestedBones(childBones, keyIndex, generalStyles)}
+            </View>
+        );
+      }
+
+      return renderBone({
+        generalStyles,
+        bonesLayout: bones,
+        index,
+        keyIndex,
+      });
+    });
+  };
+
   return useCallback(
     ({ bonesLayout, children, prefix, generalStyles }: UseGetBonesProps) => {
       if (bonesLayout && bonesLayout.length > 0) {
-        const iterator: number[] = new Array(bonesLayout.length).fill(0);
-
-        return iterator.map((_, i) => {
-          /* NOTE: Has nested layout with children */
-          if (bonesLayout[i]?.children?.length) {
-            const containerPrefix =
-              bonesLayout[i]?.key || `bone_container_${i}`;
-            const { children: childBones, ...layoutStyle } =
-              bonesLayout[i] ?? {};
-
-            return (
-              <View key={containerPrefix} style={layoutStyle}>
-                {childBones?.map((__, childIndex) =>
-                  renderBone({
-                    generalStyles,
-                    bonesLayout: childBones,
-                    index: childIndex,
-                    keyIndex: prefix ? `${prefix}_${childIndex}` : childIndex,
-                  }),
-                )}
-              </View>
-            );
-          }
-
-          return renderBone({
-            generalStyles,
-            bonesLayout,
-            index: i,
-            keyIndex: prefix ? `${prefix}_${i}` : i,
-          });
-        });
+        return renderNestedBones(bonesLayout, prefix, generalStyles);
       }
 
       return Children.map(children as JSX.Element[], (child, i) => {

--- a/packages/npm/src/hooks/useGetBones.tsx
+++ b/packages/npm/src/hooks/useGetBones.tsx
@@ -23,28 +23,35 @@ interface UseGetBonesProps {
 export const useGetBones = (componentSize: IComponentSize) => {
   const renderBone = useRenderBone(componentSize);
 
-  const renderNestedBones = (bones: ICustomViewStyle[], prefix: string | number | undefined, generalStyles: IGeneralStyles) => {
-    return bones.map((bone, index) => {
-      const keyIndex = prefix ? `${prefix}_${index}` : index;
+  const renderNestedBones = useCallback(
+    (
+      bones: ICustomViewStyle[],
+      prefix: string | number | undefined,
+      generalStyles: IGeneralStyles,
+    ) => {
+      return bones.map((bone, index) => {
+        const keyIndex = prefix ? `${prefix}_${index}` : index;
 
-      const { children: childBones, ...layoutStyle } = bone;
+        const { children: childBones, ...layoutStyle } = bone;
 
-      if (childBones?.length) {
-        return (
+        if (childBones?.length) {
+          return (
             <View key={keyIndex} style={layoutStyle}>
               {renderNestedBones(childBones, keyIndex, generalStyles)}
             </View>
-        );
-      }
+          );
+        }
 
-      return renderBone({
-        generalStyles,
-        bonesLayout: bones,
-        index,
-        keyIndex,
+        return renderBone({
+          generalStyles,
+          bonesLayout: bones,
+          index,
+          keyIndex,
+        });
       });
-    });
-  };
+    },
+    [renderBone],
+  );
 
   return useCallback(
     ({ bonesLayout, children, prefix, generalStyles }: UseGetBonesProps) => {
@@ -80,6 +87,6 @@ export const useGetBones = (componentSize: IComponentSize) => {
         );
       });
     },
-    [componentSize, renderBone],
+    [componentSize, renderNestedBones],
   );
 };

--- a/packages/web/src/Skeleton.stories.tsx
+++ b/packages/web/src/Skeleton.stories.tsx
@@ -30,10 +30,31 @@ const DEFAULT_ARGS: ISkeletonProps = {
       alignItems: 'center',
       children: [
         {
-          width: 119,
+          width: '100%',
           height: 19,
           borderRadius: 16,
           marginBottom: 8,
+          flexDirection: 'column',
+          children: [
+            {
+              width: '100%',
+              height: '100%',
+              flexDirection: 'row',
+              children: [
+                {
+                  width: 119,
+                  height: '100%',
+                  borderRadius: 16,
+                },
+                {
+                  width: 119,
+                  marginLeft: 6,
+                  height: '100%',
+                  borderRadius: 16,
+                },
+              ],
+            },
+          ],
         },
         {
           width: 234,


### PR DESCRIPTION
Add support for multi-level nesting in bones layout

This commit introduces a significant enhancement to the bones layout processing. It enables recursive rendering of nested bones, ensuring support for multi-level nested structures. The `renderNestedBones` function has been added to handle this functionality, allowing deeper flexibility and customization in bone structures. The changes include updates to types for better clarity and maintainability.

- Implement `renderNestedBones` for recursive bone rendering
- Update type definitions for `bonesLayout`, `prefix`, and `generalStyles`
- Ensure consistent key indexing for nested elements
- Refactor `useGetBones` to utilize the new recursive approach