### PR TITLE
Update expo postinstall.sh Mac/Linux compatibility.

### DIFF
--- a/packages/expo/scripts/postinstall.sh
+++ b/packages/expo/scripts/postinstall.sh
@@ -3,4 +3,11 @@ echo "Running postinstall script for react-native-reanimated-skeleton to support
 
 # Replace react-native-linear-gradient with expo-linear-gradient and LinearGradient import to { LinearGradient } with the
 # react-native-reanimated-skeleton node_module package
-find ./node_modules/react-native-reanimated-skeleton -type f -exec sed -i '' -e 's/import LinearGradient/import { LinearGradient }/g' -e 's/react-native-linear-gradient/expo-linear-gradient/g' {} +
+if [[ "$(uname)" == "Darwin" ]]; then
+    echo "Using Mac -i '' seperator for sed -i"
+    SP=" " # Needed for portability with sed
+else
+    echo "Using unix -i separator for sed."
+    SP=""
+fi
+find ./node_modules/react-native-reanimated-skeleton -type f -exec sed -i${SP}'' -e 's/import LinearGradient/import { LinearGradient }/g' -e 's/react-native-linear-gradient/expo-linear-gradient/g' {} +


### PR DESCRIPTION
We need to do `sed -i ''` on Mac vs `sed -i` on linux, see e.g.  https://stackoverflow.com/a/65646893
and
https://stackoverflow.com/questions/43171648/sed-gives-sed-cant-read-no-such-file-or-directory