### PR TITLE
Fix default value for animation direction.

### DIFF
--- a/packages/npm/src/constants/index.ts
+++ b/packages/npm/src/constants/index.ts
@@ -54,7 +54,7 @@ export const DEFAULT_CONFIG = {
   BORDER_RADIUS: 4,
   DURATION: 1200,
   ANIMATION_TYPE: 'shiver' as _animationType,
-  ANIMATION_DIRECTION: 'horizontalLeft' as _animationDirection,
+  ANIMATION_DIRECTION: 'horizontalRight' as _animationDirection,
   BONE_COLOR: '#E1E9EE',
   HIGHLIGHT_COLOR: '#F2F8FC',
   EASING: Easing.bezier(0.5, 0, 0.25, 1),


### PR DESCRIPTION
The documentation report that the default value for the animation direction is `horizontalRight`, but in reality it is `horizontalLeft`. I aligned the code to the documentation by changing the default value in the code to match the one in the readme.

@marcuzgabriel if you have  time check it, and thanks for this great library 🙏 